### PR TITLE
 Initial draft for dynamic leaderboard API implementation

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,2 @@
-# Auto detect text files and perform LF normalization
-* text=auto
+# Always convert line endings to lf on checkout
+* text eol=lf

--- a/config.js
+++ b/config.js
@@ -25,6 +25,7 @@ const defaults = {
   ENABLE_BANS_CACHE: true, // cache bans
   ENABLE_BOOSTERS_CACHE: true, // cache boosters
   ENABLE_SESSION_CACHE: true, // cache session
+  ENABLE_LEADERBOARD_CACHE: true, // cache leaderboards
   ENABLE_DB_CACHE: true, // set to enable MongoDB cache
   UUID_CACHE_SECONDS: 21600, // number of seconds to cache username-uuid pairs
   PLAYER_CACHE_SECONDS: 600, // number of seconds to cache players
@@ -32,6 +33,7 @@ const defaults = {
   BANS_CACHE_SECONDS: 30, // number of seconds to cache bans
   BOOSTERS_CACHE_SECONDS: 30, // number of seconds to cache boosters
   SESSION_CACHE_SECONDS: 60, // number of seconds to cache session
+  LEADERBOARD_CACHE_SECONDS: 900, // number of seconds to cache each leaderboard
 };
 
 // ensure that process.env has all values in defaults, but prefer the process.env value

--- a/routes/params.js
+++ b/routes/params.js
@@ -26,4 +26,58 @@ module.exports = {
       type: 'string',
     },
   },
+  typeParam: {
+    name: 'type',
+    in: 'query',
+    description: '"players" or "guilds"',
+    required: true,
+    schema: {
+      type: 'string',
+    },
+  },
+  columnParam: {
+    name: 'columns',
+    in: 'query',
+    description: 'Choose which data columns will be returned e.g. stats.Arcade.coins',
+    required: true,
+    schema: {
+      type: 'string',
+    },
+  },
+  sortByParam: {
+    name: 'sortBy',
+    in: 'query',
+    description: 'Which stat to sort records by',
+    required: true,
+    schema: {
+      type: 'string',
+    },
+  },
+  limitParam: {
+    name: 'limit',
+    in: 'query',
+    description: 'Limit number of records returned. Default is 10.',
+    required: false,
+    schema: {
+      type: 'string',
+    },
+  },
+  filterParam: {
+    name: 'filter',
+    in: 'query',
+    description: 'Filter entries by passing MongoDB query filter object as JSON string',
+    required: false,
+    schema: {
+      type: 'string',
+    },
+  },
+  significantParam: {
+    name: 'significant',
+    in: 'query',
+    description: 'Set to "false" to also return admin accounts. "true" by default.',
+    required: false,
+    schema: {
+      type: 'boolean',
+    },
+  },
 };

--- a/routes/spec.js
+++ b/routes/spec.js
@@ -5,7 +5,9 @@ const buildBans = require('../store/buildBans');
 const buildBoosters = require('../store/buildBoosters');
 const buildSession = require('../store/buildSession');
 const leaderboards = require('../store/leaderboards');
-const { playerNameParam, gameNameParam } = require('./params');
+const {
+  playerNameParam, gameNameParam, typeParam, columnParam, filterParam, sortByParam, limitParam, significantParam,
+} = require('./params');
 const packageJson = require('../package.json');
 
 const spec = {
@@ -639,7 +641,7 @@ const spec = {
         summary: 'Allows query of dynamic leaderboards',
         description: 'Returns player or guild leaderboards',
         parameters: [
-          playerNameParam,
+          typeParam, columnParam, sortByParam, filterParam, limitParam, significantParam,
         ],
         responses: {
           200: {

--- a/routes/spec.js
+++ b/routes/spec.js
@@ -661,9 +661,9 @@ const spec = {
         },
         route: () => '/leaderboards',
         func: (req, res, cb) => {
-          leaderboards(req.query, (err, lb) => {
-            if (err) {
-              return cb(res.json(err));
+          leaderboards(req.query, (error, lb) => {
+            if (error) {
+              return cb(res.json({ error }));
             }
             return res.json(lb);
           });

--- a/routes/spec.js
+++ b/routes/spec.js
@@ -4,6 +4,7 @@ const buildGuild = require('../store/buildGuild');
 const buildBans = require('../store/buildBans');
 const buildBoosters = require('../store/buildBoosters');
 const buildSession = require('../store/buildSession');
+const leaderboards = require('../store/leaderboards');
 const { playerNameParam, gameNameParam } = require('./params');
 const packageJson = require('../package.json');
 
@@ -630,6 +631,45 @@ const spec = {
         },
       },
       */
+    '/leaderboards': {
+      get: {
+        tags: [
+          'leaderboards',
+        ],
+        summary: 'Allows query of dynamic leaderboards',
+        description: 'Returns player or guild leaderboards',
+        parameters: [
+          playerNameParam,
+        ],
+        responses: {
+          200: {
+            description: 'successful operation',
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'array',
+                  items: {
+                    type: 'object',
+                    properties: {
+
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        route: () => '/leaderboards',
+        func: (req, res, cb) => {
+          leaderboards(req.query, (err, lb) => {
+            if (err) {
+              return cb(res.json(err));
+            }
+            return res.json(lb);
+          });
+        },
+      },
+    },
     '/boosters': {
       get: {
         tags: [

--- a/store/leaderboards.js
+++ b/store/leaderboards.js
@@ -65,8 +65,19 @@ function createQuery({
 function transformData(data) {
   const array = [];
   // Remove _id field from each entry
-  data.forEach((obj) => {
-    delete obj._doc._id;
+  data.forEach((doc) => {
+    const obj = doc._doc;
+    delete obj._id;
+    // Change extra columns from nested objects to keys
+    if (Object.hasOwnProperty.call(obj, 'stats')) {
+      Object.keys(obj.stats).forEach((game) => {
+        const gameObj = obj.stats[game];
+        Object.keys(gameObj).forEach((stat) => {
+          obj[`${game}_${stat}`] = gameObj[stat];
+        });
+      });
+      delete obj.stats;
+    }
     array.push(obj);
   });
   return array;

--- a/store/leaderboards.js
+++ b/store/leaderboards.js
@@ -1,0 +1,72 @@
+/*
+* Allows custom DB queries for leaderboards API endpoint
+ */
+const { profileFields } = require('../store/profileFields');
+const {
+  Player, Guild,
+} = require('../store/models');
+
+function getQueryFields(columns = '') {
+  let string = profileFields;
+  columns
+    .split(',')
+    .forEach((item) => {
+      string += ` ${item}`;
+    });
+  return string;
+}
+
+function createQuery({
+  sortBy, limit = 10, filter = '{}', significant = true,
+}) {
+  const filterObj = JSON.parse(filter) || {};
+  // TODO - Later remove non ADMIN ranked admin accounts
+  if (significant === true) {
+    filterObj.rank = { $ne: 'ADMIN' };
+  }
+  if (limit > 1000) {
+    limit = 1000;
+  }
+  return {
+    filter: filterObj,
+    options: {
+      limit: Number(limit),
+      sort: {
+        [sortBy]: -1,
+      },
+    },
+  };
+}
+
+function transformData(data) {
+  const array = [];
+  // Remove _id field from each entry
+  data.forEach((obj) => {
+    delete obj._doc._id;
+    array.push(obj);
+  });
+  return array;
+}
+
+function doStuff(query, cb) {
+  let Model;
+  const fields = getQueryFields(query.columns);
+  console.log(fields);
+  if (query.type === 'players') {
+    Model = Player;
+  } else if (query.type === 'guilds') {
+    Model = Guild;
+  } else {
+    cb('No type parameter!');
+  }
+  const { filter, options } = createQuery(query);
+  Model.find(filter, fields, options, (err, res) => {
+    if (err) {
+      console.error(err);
+      return cb(err);
+    }
+    return cb(null, transformData(res));
+  });
+}
+
+module.exports = doStuff;

--- a/store/leaderboards.js
+++ b/store/leaderboards.js
@@ -48,7 +48,7 @@ function transformData(data) {
   return array;
 }
 
-function doStuff(query, cb) {
+function getLeaderboards(query, cb) {
   let Model;
   const fields = getQueryFields(query.columns);
   console.log(fields);
@@ -69,4 +69,4 @@ function doStuff(query, cb) {
   });
 }
 
-module.exports = doStuff;
+module.exports = getLeaderboards;


### PR DESCRIPTION
Thoughts on this?

Example usage:
```HTTP
GET localhost:5000/api/leaderboards?type=players&limit=12&columns=karma,level,stats.Arcade.coins&significant=false&sortBy=karma&filter={"level": {"$gt":300}}
```
Would return player leaderboards, that
 * Are sorted by karma
 * Are limited to 12 entries
 * Have Arcade coins field in additon to default profile fields
 * Include admin accounts
 * Are filtered to players with network level above 300

TODO:
 - [x] Add caching
 - [x] Possibly add the additional stat fields in the format `GameName_field`
 - [x] Improve error handling
 - [ ] Remove admin accounts that don't have the ADMIN rank