### PR TITLE
Fixed level calculation

### DIFF
--- a/util/calculateBedWarsLevel.js
+++ b/util/calculateBedWarsLevel.js
@@ -40,9 +40,10 @@ function getLevelForExp(exp) {
   const prestiges = Math.floor(exp / XP_PER_PRESTIGE);
   let level = prestiges * LEVELS_PER_PRESTIGE;
   let expWithoutPrestiges = exp - (prestiges * XP_PER_PRESTIGE);
+  let expForEasyLevel;
 
   for (let i = 1; i <= EASY_LEVELS; i += 1) {
-    let expForEasyLevel = getExpForLevel(i);
+    expForEasyLevel = getExpForLevel(i);
     if (expWithoutPrestiges < expForEasyLevel) {
       break;
     }

--- a/util/calculateBedWarsLevel.js
+++ b/util/calculateBedWarsLevel.js
@@ -42,14 +42,14 @@ function getLevelForExp(exp) {
   let expWithoutPrestiges = exp - (prestiges * XP_PER_PRESTIGE);
 
   for (let i = 1; i <= EASY_LEVELS; i += 1) {
-    const expForEasyLevel = getExpForLevel(i);
+    let expForEasyLevel = getExpForLevel(i);
     if (expWithoutPrestiges < expForEasyLevel) {
       break;
     }
     level += 1;
     expWithoutPrestiges -= expForEasyLevel;
   }
-  return level + (expWithoutPrestiges / 5000).toFixed(2);
+  return level + Math.floor(expWithoutPrestiges / 5000);
 }
 
 module.exports = {


### PR DESCRIPTION
.toFixed(2) messed everything up.
using `const` at `const expForEasyLevel = getExpForLevel(i);` leads to inaccuracy of +1 level. Using `let` fixes that.