### PR TITLE
Added missing Build Battle fields

### DIFF
--- a/CONTRIBUTORS.js
+++ b/CONTRIBUTORS.js
@@ -8,4 +8,5 @@ module.exports = {
   '7beb3348294f44d8b967cdf0d872aff8': {}, // ecolsson
   '63fd5c413cd641e987d473df9c0e1e56': {}, // ThePoptartCrpr
   '532de453ac214ddeaec9a18a24a79e27': {}, // Cham
+  'f8a9e651e8544abd8fef5a02a75ac25a': {}, // DidiSkywalker
 };

--- a/CONTRIBUTORS.js
+++ b/CONTRIBUTORS.js
@@ -8,5 +8,5 @@ module.exports = {
   '7beb3348294f44d8b967cdf0d872aff8': {}, // ecolsson
   '63fd5c413cd641e987d473df9c0e1e56': {}, // ThePoptartCrpr
   '532de453ac214ddeaec9a18a24a79e27': {}, // Cham
-  'f8a9e651e8544abd8fef5a02a75ac25a': {}, // DidiSkywalker
+  f8a9e651e8544abd8fef5a02a75ac25a: {}, // DidiSkywalker
 };

--- a/processors/games/BuildBattle.js
+++ b/processors/games/BuildBattle.js
@@ -23,13 +23,13 @@ module.exports = ({
   active_movement_trail = null,
   selected_backdrop = null,
   packages = [],
-  ...rest,
+  ...rest
 }) => {
   // Theme ratings come in as 'votes_Theme: rating'
   // ex: 'votes_Roman: 5', 'votes_Steam Locomotive: 3'
   const themeRatings = pickKeys(rest, {
     regexp: /votes_.*/,
-    keyMap: (key) => key.replace('votes_', '')
+    keyMap: key => key.replace('votes_', ''),
   });
   return {
     coins,
@@ -51,6 +51,6 @@ module.exports = ({
     selected_movement_trail: active_movement_trail,
     selected_backdrop,
     packages,
-    themeRatings: themeRatings,
-  }
+    themeRatings,
+  };
 };

--- a/processors/games/BuildBattle.js
+++ b/processors/games/BuildBattle.js
@@ -1,8 +1,8 @@
 /* eslint-disable camelcase */
-const { getRatio } = require('../../util/utility');
+const { getRatio, pickKeys } = require('../../util/utility');
+
 /*
 * Build Battle
-* TODO - Theme vote stats
  */
 module.exports = ({
   coins = 0,
@@ -16,19 +16,41 @@ module.exports = ({
   correct_guesses = 0,
   games_played = 0,
   super_votes = 0,
+  buildbattle_loadout = [],
+  new_selected_hat = null,
+  new_victory_dance = null,
+  new_suit = null,
+  active_movement_trail = null,
+  selected_backdrop = null,
   packages = [],
-}) => ({
-  coins,
-  score,
-  wins,
-  w_r: getRatio(wins, (games_played - wins)),
-  total_votes,
-  wins_solo_normal,
-  wins_solo_pro,
-  wins_teams_normal,
-  wins_guess_the_build,
-  correct_guesses,
-  games_played,
-  super_votes,
-  packages,
-});
+  ...rest,
+}) => {
+  // Theme ratings come in as 'votes_Theme: rating'
+  // ex: 'votes_Roman: 5', 'votes_Steam Locomotive: 3'
+  const themeRatings = pickKeys(rest, {
+    regexp: /votes_.*/,
+    keyMap: (key) => key.replace('votes_', '')
+  });
+  return {
+    coins,
+    score,
+    wins,
+    w_r: getRatio(wins, (games_played - wins)),
+    total_votes,
+    wins_solo_normal,
+    wins_solo_pro,
+    wins_teams_normal,
+    wins_guess_the_build,
+    correct_guesses,
+    games_played,
+    super_votes,
+    loadout: buildbattle_loadout,
+    selected_hat: new_selected_hat,
+    selected_victory_dance: new_victory_dance,
+    selected_suit: new_suit,
+    selected_movement_trail: active_movement_trail,
+    selected_backdrop,
+    packages,
+    themeRatings: themeRatings,
+  }
+};

--- a/routes/objects.js
+++ b/routes/objects.js
@@ -862,75 +862,75 @@ const playerObject = {
             },
             score: {
               description: 'Current score in Build Battle',
-              type: 'integer'
+              type: 'integer',
             },
             wins: {
               description: 'Wins in all Build Battle modes',
-              type: 'integer'
+              type: 'integer',
             },
             w_r: {
               description: 'Win Ratio',
-              type: 'integer'
+              type: 'integer',
             },
             total_votes: {
               description: 'Judging votes on other builds',
-              type: 'integer'
+              type: 'integer',
             },
             wins_solo_normal: {
               description: 'Wins in Solo Mode',
-              type: 'integer'
+              type: 'integer',
             },
             wins_solo_pro: {
               description: 'Wins in Pro Mode',
-              type: 'integer'
+              type: 'integer',
             },
             wins_teams_normal: {
               description: 'Wins in Teams Mode',
-              type: 'integer'
+              type: 'integer',
             },
             wins_guess_the_build: {
               description: 'Wins in Guess The Build',
-              type: 'integer'
+              type: 'integer',
             },
             correct_guesses: {
               description: 'Correct guesses in Guess The Build',
-              type: 'integer'
+              type: 'integer',
             },
             games_played: {
               description: 'Post-Update games played in all modes',
-              type: 'integer'
+              type: 'integer',
             },
             super_votes: {
               description: 'Super Votes the player currently has',
-              type: 'integer'
+              type: 'integer',
             },
             loadout: {
               description: 'Custom Hotbar loadout',
-              type: 'array'
+              type: 'array',
             },
             selected_hat: {
               description: 'Currently selected hat cosmetic',
-              type: 'string'
+              type: 'string',
             },
             selected_victory_dance: {
               description: 'Currently selected victory dance cosmetic',
-              type: 'string'
+              type: 'string',
             },
             selected_suit: {
               description: 'Currently selected suit cosmetic',
-              type: 'string'
+              type: 'string',
             },
             selected_movement_trail: {
               description: 'Currently selected movement trail cosmetic',
-              type: 'string'
+              type: 'string',
             },
             selected_backdrop: {
               description: 'Currently selected backdrop cosmetic',
-              type: 'string'
+              type: 'string',
             },
             themeRatings: {
               description: 'Key-Value pairs of 1-5 star ratings on themes',
-              type: 'object'
+              type: 'object',
             },
           },
         },

--- a/routes/objects.js
+++ b/routes/objects.js
@@ -860,6 +860,78 @@ const playerObject = {
               description: 'Current coins in Build Battle',
               type: 'integer',
             },
+            score: {
+              description: 'Current score in Build Battle',
+              type: 'integer'
+            },
+            wins: {
+              description: 'Wins in all Build Battle modes',
+              type: 'integer'
+            },
+            w_r: {
+              description: 'Win Ratio',
+              type: 'integer'
+            },
+            total_votes: {
+              description: 'Judging votes on other builds',
+              type: 'integer'
+            },
+            wins_solo_normal: {
+              description: 'Wins in Solo Mode',
+              type: 'integer'
+            },
+            wins_solo_pro: {
+              description: 'Wins in Pro Mode',
+              type: 'integer'
+            },
+            wins_teams_normal: {
+              description: 'Wins in Teams Mode',
+              type: 'integer'
+            },
+            wins_guess_the_build: {
+              description: 'Wins in Guess The Build',
+              type: 'integer'
+            },
+            correct_guesses: {
+              description: 'Correct guesses in Guess The Build',
+              type: 'integer'
+            },
+            games_played: {
+              description: 'Post-Update games played in all modes',
+              type: 'integer'
+            },
+            super_votes: {
+              description: 'Super Votes the player currently has',
+              type: 'integer'
+            },
+            loadout: {
+              description: 'Custom Hotbar loadout',
+              type: 'array'
+            },
+            selected_hat: {
+              description: 'Currently selected hat cosmetic',
+              type: 'string'
+            },
+            selected_victory_dance: {
+              description: 'Currently selected victory dance cosmetic',
+              type: 'string'
+            },
+            selected_suit: {
+              description: 'Currently selected suit cosmetic',
+              type: 'string'
+            },
+            selected_movement_trail: {
+              description: 'Currently selected movement trail cosmetic',
+              type: 'string'
+            },
+            selected_backdrop: {
+              description: 'Currently selected backdrop cosmetic',
+              type: 'string'
+            },
+            themeRatings: {
+              description: 'Key-Value pairs of 1-5 star ratings on themes',
+              type: 'object'
+            },
           },
         },
         Duels: {


### PR DESCRIPTION
I added some missing Build Battle fields and implemented that TODO there. Hope it's okay I rebranded  the theme "votes" as ratings, because that's really what they are and votes already has two different meanings in Build Battle. They're added to the Build Battle stats like this now
```
themeRatings: {
  Roman: 5,
  'Steam Locomotive': 3,
  etc
}
```
Also updated the Build Battle documentation.

Not sure if this is enough contribution to deserve a mention in the contributors list, so feel free to remove me if not. Just figured it's easier for you to remove than for me to add afterwards.