### PR TITLE
Add the profile name to returned json

### DIFF
--- a/routes/spec.js
+++ b/routes/spec.js
@@ -1893,6 +1893,9 @@ Consider supporting The Slothpixel Project on Patreon to help cover the hosting 
                         },
                       },
                     },
+                    cute_name: {
+                      type: 'string',
+                    },
                   },
                 },
               },

--- a/store/buildSkyBlockProfiles.js
+++ b/store/buildSkyBlockProfiles.js
@@ -97,8 +97,8 @@ async function buildProfile(uuid, id = null) {
 
     return getProfileData(profile_id);
   }, { cacheDuration: 600 });
-  returnedProfile.cute_name = profiles[profile_id].cute_name.toLowerCase(); //add profile name to the end of the profile
-  return returnedProfile; //return appended profile object
+  returnedProfile.cute_name = profiles[profile_id].cute_name || ''; // add profile name to the end of the profile
+  return returnedProfile; // return appended profile object
 }
 
 module.exports = {

--- a/store/buildSkyBlockProfiles.js
+++ b/store/buildSkyBlockProfiles.js
@@ -92,11 +92,13 @@ async function buildProfile(uuid, id = null) {
   }
 
   // eslint-disable-next-line arrow-body-style
-  return cachedFunction(`skyblock_profile:${profile_id}`, async () => {
+  returned_Profile = await cachedFunction(`skyblock_profile:${profile_id}`, async () => {
     // insertSkyBlockProfile(profile);
 
     return getProfileData(profile_id);
   }, { cacheDuration: 600 });
+  returned_Profile["cute_name"] = profiles[profile_id].cute_name.toLowerCase() //add profile name to the end of the profile
+  return returned_Profile //return appended profile object
 }
 
 module.exports = {

--- a/store/buildSkyBlockProfiles.js
+++ b/store/buildSkyBlockProfiles.js
@@ -92,7 +92,7 @@ async function buildProfile(uuid, id = null) {
   }
 
   // eslint-disable-next-line arrow-body-style
-  returnedProfile = await cachedFunction(`skyblock_profile:${profile_id}`, async () => {
+  const returnedProfile = await cachedFunction(`skyblock_profile:${profile_id}`, async () => {
     // insertSkyBlockProfile(profile);
 
     return getProfileData(profile_id);

--- a/store/buildSkyBlockProfiles.js
+++ b/store/buildSkyBlockProfiles.js
@@ -92,13 +92,13 @@ async function buildProfile(uuid, id = null) {
   }
 
   // eslint-disable-next-line arrow-body-style
-  returned_Profile = await cachedFunction(`skyblock_profile:${profile_id}`, async () => {
+  returnedProfile = await cachedFunction(`skyblock_profile:${profile_id}`, async () => {
     // insertSkyBlockProfile(profile);
 
     return getProfileData(profile_id);
   }, { cacheDuration: 600 });
-  returned_Profile["cute_name"] = profiles[profile_id].cute_name.toLowerCase() //add profile name to the end of the profile
-  return returned_Profile //return appended profile object
+  returnedProfile.cute_name = profiles[profile_id].cute_name.toLowerCase() //add profile name to the end of the profile
+  return returnedProfile //return appended profile object
 }
 
 module.exports = {

--- a/store/buildSkyBlockProfiles.js
+++ b/store/buildSkyBlockProfiles.js
@@ -97,8 +97,8 @@ async function buildProfile(uuid, id = null) {
 
     return getProfileData(profile_id);
   }, { cacheDuration: 600 });
-  returnedProfile.cute_name = profiles[profile_id].cute_name.toLowerCase() //add profile name to the end of the profile
-  return returnedProfile //return appended profile object
+  returnedProfile.cute_name = profiles[profile_id].cute_name.toLowerCase(); //add profile name to the end of the profile
+  return returnedProfile; //return appended profile object
 }
 
 module.exports = {


### PR DESCRIPTION
In the endpoint /skyblock/profile/:player/:profile?

Using code that was already in **store/buildSkyBlockProfiles.js** I changed around how buildProfile() was returned so that it also includes the profile name which will mean that people will not have to go to the endpoint /skyblock/profiles/:player to get the latest profile meaning it will result in less unnecessary requests due to the fact it would now include the name in the returned JSON.