### PR TITLE
fix: monthlyPackageRank having priority over rank

### DIFF
--- a/processors/processPlayerData.js
+++ b/processors/processPlayerData.js
@@ -21,11 +21,11 @@ function getPlayerRank(rank, packageRank, newPackageRank, monthlyPackageRank) {
     playerRank = rank || newPackageRank || packageRank || null;
   }
 
-  if (monthlyPackageRank === 'SUPERSTAR') {
+  if (playerRank === 'SUPERSTAR') {
     playerRank = 'MVP_PLUS_PLUS';
   }
 
-  if (rank === 'NONE') {
+  if (playerRank === 'NONE') {
     playerRank = null;
   }
   return playerRank;

--- a/processors/processPlayerData.js
+++ b/processors/processPlayerData.js
@@ -15,10 +15,11 @@ const parseQuests = require('./parseQuests');
 
 function getPlayerRank(rank, packageRank, newPackageRank, monthlyPackageRank) {
   let playerRank;
+  if (monthlyPackageRank === 'NONE') monthlyPackageRank = null
   if (rank === 'NORMAL') {
-    playerRank = newPackageRank || packageRank || null;
+    playerRank = monthlyPackageRank || newPackageRank || packageRank || null;
   } else {
-    playerRank = rank || newPackageRank || packageRank || null;
+    playerRank = rank || monthlyPackageRank || newPackageRank || packageRank || null;
   }
 
   if (playerRank === 'SUPERSTAR') {


### PR DESCRIPTION
This PR fixes an issue with people with a "rank" and a "monthlyPackageRank" where the latter would take priority on the "rank" property.