### PR TITLE
Improvements to the guild and player endpoints

### DIFF
--- a/processors/processGuildData.js
+++ b/processors/processGuildData.js
@@ -74,7 +74,7 @@ function insertDefaultRanks(ranks, created) {
 }
 
 function getPreferredGames(games) {
-  return games.map((game) => utility.typeToStandardName(game));
+  return games.map((game) => utility.typeToCleanName(game));
 }
 
 function processMember({

--- a/processors/processGuildData.js
+++ b/processors/processGuildData.js
@@ -150,7 +150,7 @@ function processGuildData({
     exp_history: expHistory,
     description,
     preferred_games: getPreferredGames(preferredGames),
-    ranks: insertDefaultRanks(ranks, created),
+    ranks: insertDefaultRanks(ranks, created).sort(r => -r.priority),
     members: processedMembers,
     achievements,
   };

--- a/processors/processPlayerData.js
+++ b/processors/processPlayerData.js
@@ -4,7 +4,7 @@ const {
   generateFormattedRank,
   colorNameToCode,
   betterFormatting,
-  typeToStandardName,
+  typeToCleanName,
   isContributor,
 } = require('../util/utility');
 const calculateLevel = require('../util/calculateLevel');
@@ -178,7 +178,7 @@ function processPlayerData({
     first_login: getFirstLogin(firstLogin, _id),
     last_login: lastLogin,
     last_logout: lastLogout,
-    last_game: typeToStandardName(mostRecentGameType),
+    last_game: typeToCleanName(mostRecentGameType),
     language: userLanguage,
     gifts_sent: realBundlesGiven,
     gifts_received: realBundlesReceived,

--- a/routes/graphql.js
+++ b/routes/graphql.js
@@ -21,7 +21,7 @@ const redis = require('../store/redis');
 const getUUID = require('../store/getUUID');
 const { getMetadata } = require('../store/queries');
 const {
-  logger, generateJob, getData, typeToStandardName,
+  logger, generateJob, getData, typeToCleanName,
 } = require('../util/utility');
 
 const leaderboardsAsync = pify(leaderboards);
@@ -79,7 +79,7 @@ class PlayersResolver {
     const data = await getData(redis, generateJob('recentgames', { id: uuid }).url);
 
     return data.games.map((game) => {
-      game.gameType = typeToStandardName(game.gameType);
+      game.gameType = typeToCleanName(game.gameType);
       return game;
     });
   }

--- a/routes/spec.js
+++ b/routes/spec.js
@@ -17,7 +17,7 @@ const { playerObject } = require('./objects');
 const { populatePlayers, getPlayer, PlayerError } = require('../store/buildPlayer');
 const { getMetadata } = require('../store/queries');
 const {
-  logger, generateJob, getData, typeToStandardName, getPlayerFields,
+  logger, generateJob, getData, typeToCleanName, getPlayerFields,
 } = require('../util/utility');
 const {
   playerNameParam, gameNameParam, typeParam, columnParam, filterParam, sortByParam,
@@ -611,7 +611,7 @@ Consider supporting The Slothpixel Project on Patreon to help cover the hosting 
             try {
               const { games } = await getData(redis, generateJob('recentgames', { id: uuid }).url);
               response.json(games.map((game) => {
-                game.gameType = typeToStandardName(game.gameType);
+                game.gameType = typeToCleanName(game.gameType);
                 return game;
               }));
             } catch (error) {

--- a/util/utility.js
+++ b/util/utility.js
@@ -134,6 +134,14 @@ function typeToStandardName(name) {
 }
 
 /**
+ * Converts minigame types into clean names e.g. TNTGAMES => TNT Games
+ */
+function typeToCleanName(name) {
+  const result = constants.game_types.find((game) => game.type_name === name)
+  return result === undefined ? name : result.clean_name
+}
+
+/**
  * Determines if a player has contributed to the development of Slothpixel
  */
 const isContributor = (uuid) => contributors.includes(uuid);
@@ -450,6 +458,7 @@ module.exports = {
   IDToStandardName,
   DBToStandardName,
   typeToStandardName,
+  typeToCleanName,
   isContributor,
   getNestedObjects,
   getPlayerFields,


### PR DESCRIPTION
This PR only changes 2 small things:
- Sorts guild ranks by descending priority in the guild endpoint
- Creates the typeToCleanName function in utility which replaces most instances of typeToStandardName (all except the following one)
https://github.com/slothpixel/core/blob/a65dc5b6d26b794631d92901907666c64101fc0a/processors/processGuildData.js#L51-L59

The reason for the second change is because the clean_name property from hypixelconstants is a more readable name than standard_name (it includes spaces and the full popular name of minigames) and is the one Hypixel mentions in the API reference.

While making this PR I also found an issue with the guild endpoint that I chose to report at #690 since I couldn't find a fix for it.