### PR TITLE
Fix tag_formatted rendering when tag is null

### DIFF
--- a/processors/processGuildData.js
+++ b/processors/processGuildData.js
@@ -142,7 +142,7 @@ function processGuildData({
     public: publiclyListed,
     tag: guildTag,
     tag_color,
-    tag_formatted: `${tag_color}[${guildTag}]`,
+    tag_formatted: guildTag ? `${tag_color}[${guildTag}]` : null,
     legacy_ranking: legacyRanking + 1,
     exp,
     level: getLevel(exp),


### PR DESCRIPTION
This PR fixes a but where tag_formatted would always be set regardless of the value of tag. This will now be null if tag is also null, instead of displaying &7[null]