### PR TITLE
Fix rank sort function

### DIFF
--- a/processors/processGuildData.js
+++ b/processors/processGuildData.js
@@ -135,7 +135,7 @@ function processGuildData({
   const guildTag = utility.betterFormatting(tag);
   const tag_color = utility.colorNameToCode(tagColor);
   return {
-    guild: true
+    guild: true,
     name,
     id: _id,
     created,

--- a/processors/processGuildData.js
+++ b/processors/processGuildData.js
@@ -135,6 +135,7 @@ function processGuildData({
   const guildTag = utility.betterFormatting(tag);
   const tag_color = utility.colorNameToCode(tagColor);
   return {
+    guild: true
     name,
     id: _id,
     created,
@@ -150,7 +151,7 @@ function processGuildData({
     exp_history: expHistory,
     description,
     preferred_games: getPreferredGames(preferredGames),
-    ranks: insertDefaultRanks(ranks, created).sort((r) => -r.priority),
+    ranks: insertDefaultRanks(ranks, created).sort((a, b) => b.priority - a.priority),
     members: processedMembers,
     achievements,
   };


### PR DESCRIPTION
So in the PR that I tried to sort the guild ranks array I managed to fuck up the sort function so bad it didn't even make sense, so this PR fixes that and this time it was properly tested so this will work.
Also added a `guild: true` property to make it easier to check if we get a guild back from the API request or not.