### PR TITLE
Fix graphql not working with the guilds endpoint

### DIFF
--- a/processors/processGuildData.js
+++ b/processors/processGuildData.js
@@ -149,7 +149,7 @@ function processGuildData({
     level: getLevel(exp),
     exp_by_game: expByGame,
     exp_history: expHistory,
-    guild_master: processedMembers.find(m => m.rank === "Guild Master"),
+    guild_master: processedMembers.find((m) => m.rank === 'Guild Master'),
     description,
     preferred_games: getPreferredGames(preferredGames),
     ranks: insertDefaultRanks(ranks, created).sort((a, b) => b.priority - a.priority),

--- a/processors/processGuildData.js
+++ b/processors/processGuildData.js
@@ -149,6 +149,7 @@ function processGuildData({
     level: getLevel(exp),
     exp_by_game: expByGame,
     exp_history: expHistory,
+    guild_master: processedMembers.find(m => m.rank === "Guild Master"),
     description,
     preferred_games: getPreferredGames(preferredGames),
     ranks: insertDefaultRanks(ranks, created).sort((a, b) => b.priority - a.priority),

--- a/routes/spec.graphql
+++ b/routes/spec.graphql
@@ -1613,6 +1613,11 @@ type Guild {
   description: String
 
   """
+  Member object of the guild master
+  """
+  guild_master: MembersListItem
+
+  """
   Total guild xp
   """
   exp: Int

--- a/routes/spec.graphql
+++ b/routes/spec.graphql
@@ -1603,6 +1603,11 @@ type Games {
 
 type Guild {
   """
+  Value indicating the success, or not, of the operation. Can be either true or null
+  """
+  guild: Boolean
+
+  """
   Guild creation date
   """
   created: Float

--- a/routes/spec.js
+++ b/routes/spec.js
@@ -244,9 +244,9 @@ The Slothpixel API provides Hypixel related data.
 Currently the API has a rate limit of **60 requests/minute** and **50,000 requests per month**. If you have higher data needs contact the admins on discord.
 
 Consider supporting The Slothpixel Project on Patreon to help cover the hosting costs.
-    
-[Discord](https://discord.gg/ND9bJKK) | [Patreon](https://patreon.com/slothpixel)  
-    
+
+[Discord](https://discord.gg/ND9bJKK) | [Patreon](https://patreon.com/slothpixel)
+
 # GraphQL
     Slothpixel API supports the use of GraphQL query language, and it is recommended for advanced users. [Read more](https://github.com/slothpixel/core/wiki/GraphQL)
     `,
@@ -263,9 +263,9 @@ Consider supporting The Slothpixel Project on Patreon to help cover the hosting 
         type: 'apiKey',
         name: 'key',
         description: `Use an API key to remove monthly call limits and to receive higher rate limits.
-      
+
       Usage example: https://api.slothpixel.me/api/players/slothpixel?key=YOUR-API-KEY
-      
+
       API key can also be sent using the authorization header "Authorization: Bearer YOUR-API-KEY"
       `,
         in: 'query',
@@ -794,6 +794,36 @@ Consider supporting The Slothpixel Project on Patreon to help cover the hosting 
                       description: 'Guild description',
                       type: 'string',
                     },
+                    guild_master: {
+                      description: 'Member object of the guild master',
+                      type: 'object',
+                      properties: {
+                        uuid: {
+                          description: 'Player UUID',
+                          type: 'string',
+                        },
+                        rank: {
+                          description: 'Player rank in the guild',
+                          type: 'string',
+                        },
+                        joined: {
+                          description: 'Member join date',
+                          type: 'integer',
+                        },
+                        quest_participation: {
+                          description: 'How many much the member has contributed to guild quests',
+                          type: 'integer',
+                        },
+                        exp_history: {
+                          description: 'Contains raw guild xp earned in the past week. Uses format YYYY-MM-DD.',
+                          type: 'object',
+                        },
+                        muted_till: {
+                          description: 'Date the member is muted until',
+                          type: 'integer',
+                        },
+                      },
+                    },
                     preferred_games: {
                       description: 'Array containing the guild\'s preferred games',
                       type: 'array',
@@ -956,6 +986,36 @@ Consider supporting The Slothpixel Project on Patreon to help cover the hosting 
                       description: 'Guild description',
                       type: 'string',
                     },
+                    guild_master: {
+                      description: 'Member object of the guild master',
+                      type: 'object',
+                      properties: {
+                        uuid: {
+                          description: 'Player UUID',
+                          type: 'string',
+                        },
+                        rank: {
+                          description: 'Player rank in the guild',
+                          type: 'string',
+                        },
+                        joined: {
+                          description: 'Member join date',
+                          type: 'integer',
+                        },
+                        quest_participation: {
+                          description: 'How many much the member has contributed to guild quests',
+                          type: 'integer',
+                        },
+                        exp_history: {
+                          description: 'Contains raw guild xp earned in the past week. Uses format YYYY-MM-DD.',
+                          type: 'object',
+                        },
+                        muted_till: {
+                          description: 'Date the member is muted until',
+                          type: 'integer',
+                        },
+                      },
+                    },
                     preferred_games: {
                       description: 'Array containing the guild\'s preferred games',
                       type: 'array',
@@ -1111,6 +1171,36 @@ Consider supporting The Slothpixel Project on Patreon to help cover the hosting 
                     description: {
                       description: 'Guild description',
                       type: 'string',
+                    },
+                    guild_master: {
+                      description: 'Member object of the guild master',
+                      type: 'object',
+                      properties: {
+                        uuid: {
+                          description: 'Player UUID',
+                          type: 'string',
+                        },
+                        rank: {
+                          description: 'Player rank in the guild',
+                          type: 'string',
+                        },
+                        joined: {
+                          description: 'Member join date',
+                          type: 'integer',
+                        },
+                        quest_participation: {
+                          description: 'How many much the member has contributed to guild quests',
+                          type: 'integer',
+                        },
+                        exp_history: {
+                          description: 'Contains raw guild xp earned in the past week. Uses format YYYY-MM-DD.',
+                          type: 'object',
+                        },
+                        muted_till: {
+                          description: 'Date the member is muted until',
+                          type: 'integer',
+                        },
+                      },
                     },
                     preferred_games: {
                       description: 'Array containing the guild\'s preferred games',

--- a/routes/spec.js
+++ b/routes/spec.js
@@ -746,6 +746,10 @@ Consider supporting The Slothpixel Project on Patreon to help cover the hosting 
                 schema: {
                   type: 'object',
                   properties: {
+                    guild: {
+                      description: 'Value indicating the success, or not, of the operation. Can be either true or null',
+                      type: 'boolean',
+                    },
                     name: {
                       description: 'Guild\'s name',
                       type: 'string',
@@ -938,6 +942,10 @@ Consider supporting The Slothpixel Project on Patreon to help cover the hosting 
                 schema: {
                   type: 'object',
                   properties: {
+                    guild: {
+                      description: 'Value indicating the success, or not, of the operation. Can be either true or null',
+                      type: 'boolean',
+                    },
                     name: {
                       description: 'Guild\'s name',
                       type: 'string',
@@ -1124,6 +1132,10 @@ Consider supporting The Slothpixel Project on Patreon to help cover the hosting 
                 schema: {
                   type: 'object',
                   properties: {
+                    guild: {
+                      description: 'Value indicating the success, or not, of the operation. Can be either true or null',
+                      type: 'boolean',
+                    },
                     name: {
                       description: 'Guild\'s name',
                       type: 'string',


### PR DESCRIPTION
This PR adds a new property to the guilds endpoint called guild_master which holds the member object corresponding to the guild master from the members array. This is done so that users that only need the master's data can retrieve it with populate_players set to false.