### PR TITLE
fix skyblock/profiles endpoint empty when uncached on graphql

### DIFF
--- a/routes/graphql.js
+++ b/routes/graphql.js
@@ -13,7 +13,7 @@ const buildBoosters = require('../store/buildBoosters');
 const buildCounts = require('../store/buildCounts');
 const buildPlayerStatus = require('../store/buildPlayerStatus');
 const { getAuctions, queryAuctionId } = require('../store/queryAuctions');
-const { buildProfile } = require('../store/buildSkyBlockProfiles');
+const { buildProfileList, buildProfile } = require('../store/buildSkyBlockProfiles');
 const { buildSkyblockCalendar, buildSkyblockEvents } = require('../store/buildSkyblockCalendar');
 const buildGuild = require('../store/buildGuild');
 const leaderboards = require('../store/leaderboards');
@@ -112,7 +112,7 @@ class SkyblockResolver {
   async profiles({ player_name }) {
     const uuid = await getUUID(player_name);
     const profiles = await redis.get(`skyblock_profiles:${uuid}`);
-    return profiles ? JSON.parse(profiles) : {};
+    return profiles ? JSON.parse(profiles) : buildProfileList(uuid);
   }
 
   async profile({ player_name, profile_id }) {


### PR DESCRIPTION
This PR should fix a bug with graphql on the skyblock/profiles endpoint where it would return an empty object when the data isn't cached. It simply mimics the behavior on spec.js which is why I'm saying it *should* fix the issue