### PR TITLE
GraphQL: fix per-game achievements

### DIFF
--- a/routes/graphql.js
+++ b/routes/graphql.js
@@ -63,8 +63,9 @@ class PlayersResolver {
   }
 
   async achievements({ player_name }) {
-    const player = await getPlayer(player_name);
-    return player.achievements;
+    const { achievements } = await getPlayer(player_name);
+    achievements.games = Object.keys(achievements.games).map((key) => Object.assign({ name: key }, achievements.games[key]));
+    return achievements
   }
 
   async quests({ player_name }) {

--- a/routes/graphql.js
+++ b/routes/graphql.js
@@ -64,8 +64,8 @@ class PlayersResolver {
 
   async achievements({ player_name }) {
     const { achievements } = await getPlayer(player_name);
-    achievements.games = Object.keys(achievements.games).map((key) => Object.assign({ name: key }, achievements.games[key]));
-    return achievements
+    achievements.games = Object.keys(achievements.games).map((key) => ({ name: key, ...achievements.games[key] }));
+    return achievements;
   }
 
   async quests({ player_name }) {

--- a/routes/spec.graphql
+++ b/routes/spec.graphql
@@ -1570,7 +1570,7 @@ type Gamemodes {
 type Game {
 
   """
-  Name of the game, according to the hypixel API
+  Name of the game, according to slothpixel's standard naming
   """
   name: String
 

--- a/routes/spec.graphql
+++ b/routes/spec.graphql
@@ -1567,7 +1567,13 @@ type Gamemodes {
   two_v_two: TwoVTwo
 }
 
-type Games {
+type Game {
+
+  """
+  Name of the game, according to the hypixel API
+  """
+  name: String
+
   """
   Total achievements completed in the game
   """
@@ -1587,7 +1593,7 @@ type Games {
   """
   Total achievement points in the game
   """
-  points: Int
+  points_total: Int
 
   """
   Total achievement points from one time achievements in the game
@@ -1598,7 +1604,7 @@ type Games {
   Total achievement points from tiered achievements in the game
   """
   points_tiered: Int
-  tiered: [Int]
+  tiered: JSON
 }
 
 type Guild {
@@ -2422,7 +2428,7 @@ type PlayerAchievements {
   Total achievements completed
   """
   completed_total: Int
-  games: Games
+  games: [Game]
   rewards: JSON
 }
 


### PR DESCRIPTION
Stats for individual games always return `null` through graphql due to
the dynamic keys (names), so an array is required.

The name of each game can be found under a `name` field for each game,
rather than as a key in an object.

It seems that this is the preferred method over having to request
achievements for each game separately.

Also fixed the type for `tiered` (should possibly have the same
object-to-array as above, but I have changed it for the untyped `JSON`)
and renamed `points` to `points_total` to be consistent with the REST
API.