### PR TITLE
refactor: remove name_history from player stats endpoint

### DIFF
--- a/processors/processPlayerData.js
+++ b/processors/processPlayerData.js
@@ -70,7 +70,6 @@ function processPlayerData({
   rankPlusColor = 'RED',
   monthlyRankColor = 'GOLD',
   karma = 0,
-  knownAliases = [],
   networkExp = 0,
   achievementPoints = 0,
   mcVersionRp = null,
@@ -163,7 +162,6 @@ function processPlayerData({
   return {
     uuid,
     username: displayname,
-    name_history: knownAliases,
     online: getOnlineStatus(lastLogin, lastLogout),
     rank: newRank,
     rank_plus_color: newRankPlusColor,

--- a/routes/objects.js
+++ b/routes/objects.js
@@ -9,10 +9,6 @@ const playerObject = {
       description: 'Player username',
       type: 'string',
     },
-    name_history: {
-      description: 'History of usernames the user has joined Hypixel with',
-      type: 'array',
-    },
     online: {
       description: 'Is player online',
       type: 'boolean',

--- a/test/data/player.json
+++ b/test/data/player.json
@@ -816,12 +816,6 @@
     "displayname": "builder_247",
     "firstLogin": 1380380142629,
     "karma": 71969935,
-    "knownAliases": [
-      "builder_247"
-    ],
-    "knownAliasesLower": [
-      "builder_247"
-    ],
     "lastLogin": 1536750681408,
     "networkExp": 1.34761294E8,
     "newClock": "LVL2",


### PR DESCRIPTION
As Mojang has [recently announced](https://help.minecraft.net/hc/en-us/articles/8969841895693-Username-History-API-Removal-FAQ-) they will be removing the name history API on September 13th. Due to this, Hypixel has removed the knownAliases and knownAliasesLower fields have been removed from the player stats endpoint. I have gone ahead and removed the name_history field from the API as this has been returning an empty array ever since this change. The field was not present in the graphql schema which leads me to believe that might be outdated but I'll leave that for another PR if someone wants to take a look at that