### PR TITLE
refactor: add ranks given to player stats endpoint

### DIFF
--- a/processors/processPlayerData.js
+++ b/processors/processPlayerData.js
@@ -75,7 +75,7 @@ function processPlayerData({
   mcVersionRp = null,
   mostRecentGameType = null,
   userLanguage = 'ENGLISH',
-  giftingMeta: { realBundlesGiven = 0, realBundlesReceived = 0 } = {},
+  giftingMeta: { realBundlesGiven = 0, realBundlesReceived = 0, ranksGiven = 0 } = {},
   rewardScore = 0,
   rewardHighScore = 0,
   totalRewards = 0,
@@ -184,6 +184,7 @@ function processPlayerData({
     language: userLanguage,
     gifts_sent: realBundlesGiven,
     gifts_received: realBundlesReceived,
+    ranks_sent: ranksGiven,
     is_contributor: isContributor(uuid),
     rewards: {
       streak_current: rewardScore,

--- a/routes/objects.js
+++ b/routes/objects.js
@@ -98,6 +98,10 @@ const playerObject = {
       description: 'Total gifts received from other players',
       type: 'integer',
     },
+    ranks_sent: {
+      description: 'Total ranks sent to other players',
+      type: 'integer'
+    },
     is_contributor: {
       description: 'Whether player is a contributor to Slothpixel',
       type: 'boolean',

--- a/test/data/player.json
+++ b/test/data/player.json
@@ -37970,6 +37970,7 @@
         "FIFTY",
         "ONE_HUNDRED"
       ],
+      "ranksGiven": 122,
       "realBundlesReceived": 182,
       "bundlesReceived": 182
     },


### PR DESCRIPTION
First PR on Github, hopefully I'm doing this right! Slothpixel does not show how many ranks a player has gifted, so this commit adds that :)