### PR TITLE
Add TikTok link

### DIFF
--- a/processors/processPlayerData.js
+++ b/processors/processPlayerData.js
@@ -109,6 +109,7 @@ function processPlayerData({
     TWITCH: null,
     DISCORD: null,
     HYPIXEL: null,
+    TIKTOK: null,
   };
   const defaultStatsObject = {
     Arcade: {},

--- a/routes/objects.js
+++ b/routes/objects.js
@@ -178,6 +178,10 @@ const playerObject = {
           description: 'Link to Hypixel Forums profile',
           type: 'string',
         },
+        TIKTOK: {
+          description: 'Link to TikTok profile',
+          type: 'string',
+        },
       },
     },
     stats: {

--- a/routes/spec.graphql
+++ b/routes/spec.graphql
@@ -1846,6 +1846,11 @@ type Links {
   Link to YouTube channel
   """
   YOUTUBE: String
+  
+  """
+  Link to TikTok profile
+  """
+  TIKTOK: String
 }
 
 """


### PR DESCRIPTION
Hypixel recently added the support for linking a TikTok profile to your account as mentioned in [this forum post](https://hypixel.net/threads/network-update-improved-leaderboards-increased-network-experience-and-more.5201519/), however it doesn't seem like their API supports it yet.